### PR TITLE
feat: implement User Signature management and improve RFQ handling

### DIFF
--- a/rfq_opening_process/controllers/generate_template.py
+++ b/rfq_opening_process/controllers/generate_template.py
@@ -1,11 +1,10 @@
 from collections import defaultdict
 from datetime import datetime
 
+
 import frappe
 from frappe.query_builder import DocType
-
-
-from datetime import datetime
+from frappe.utils import getdate
 
 
 def format_date_with_ordinal(date_obj):
@@ -15,8 +14,7 @@ def format_date_with_ordinal(date_obj):
     else:
         suffix = {1: "st", 2: "nd", 3: "rd"}.get(day % 10, "th")
 
-    formatted_date = date_obj.strftime(f"%d{suffix} %B, %Y")
-    return formatted_date
+    return f"{day}{suffix} {date_obj.strftime('%B, %Y')}"
 
 
 def get_supplier_quotations(rfq):
@@ -114,9 +112,9 @@ def generate_template(quotation, committee, note_type, date, evaluation_committe
     context["transaction_date"] = format_date_with_ordinal(
         datetime.strptime(rfq_doc.get_formatted("transaction_date"), "%d-%m-%Y")
     )
-    context["opening_date"] = datetime.strptime(
-        rfq_doc.get_formatted("closing_date"), "%d-%m-%Y"
-    ).strftime("%d/%m/%Y")
+    context["opening_date"] = getdate(rfq_doc.get_formatted("closing_date")).strftime(
+        "%d/%m/%Y"
+    )
     context["closing_date"] = format_date_with_ordinal(
         datetime.strptime(rfq_doc.get_formatted("closing_date"), "%d-%m-%Y")
     )

--- a/rfq_opening_process/hooks.py
+++ b/rfq_opening_process/hooks.py
@@ -39,6 +39,7 @@ required_apps = ["frappe/erpnext"]
 # doctype_js = {"doctype" : "public/js/doctype.js"}
 doctype_js = {
     "ToDo": "public/js/todo.js",
+    "Request for Quotation": "public/js/request_for_quotation.js",
 }
 
 doctype_list_js = {

--- a/rfq_opening_process/patches.txt
+++ b/rfq_opening_process/patches.txt
@@ -1,5 +1,5 @@
 [pre_model_sync]
 
-
 [post_model_sync]
 rfq_opening_process.rfq_opening_process.patches.user_custom_field
+rfq_opening_process.rfq_opening_process.patches.user_signature_migration

--- a/rfq_opening_process/public/js/request_for_quotation.js
+++ b/rfq_opening_process/public/js/request_for_quotation.js
@@ -1,0 +1,10 @@
+frappe.ui.form.on("Request for Quotation", {
+    refresh: function(frm) {
+        frappe.db.get_single_value("RFQ Opening Settings", "require_mandatory_on_rfq").then(value => {
+            frm.set_df_property("minimum_expected_quotes", "reqd", value ? 1 : 0);
+            frm.set_df_property("committee", "reqd", value ? 1 : 0);
+            frm.set_df_property("closing_date", "reqd", value ? 1 : 0);
+            frm.set_df_property("closing_time", "reqd", value ? 1 : 0);
+        });
+    }
+});

--- a/rfq_opening_process/rfq_opening_process/doctype/committee/committee.json
+++ b/rfq_opening_process/rfq_opening_process/doctype/committee/committee.json
@@ -30,7 +30,7 @@
    "fieldname": "committee_name",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Committee",
+   "label": "Committee Name",
    "reqd": 1,
    "unique": 1
   },
@@ -116,7 +116,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-26 13:02:39.353198",
+ "modified": "2025-08-11 13:02:50.975861",
  "modified_by": "Administrator",
  "module": "RFQ Opening Process",
  "name": "Committee",
@@ -149,6 +149,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "committee_name",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/rfq_opening_process/rfq_opening_process/doctype/committee_member/committee_member.json
+++ b/rfq_opening_process/rfq_opening_process/doctype/committee_member/committee_member.json
@@ -30,22 +30,23 @@
    "label": "Full Name"
   },
   {
-   "fetch_from": "user_id.signature",
    "fieldname": "signature",
    "fieldtype": "Attach",
+   "in_list_view": 1,
    "label": "Signature"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-04 14:48:09.162627",
+ "modified": "2025-08-09 10:49:22.892307",
  "modified_by": "Administrator",
  "module": "RFQ Opening Process",
  "name": "Committee Member",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/rfq_opening_process/rfq_opening_process/doctype/committee_member/committee_member.json
+++ b/rfq_opening_process/rfq_opening_process/doctype/committee_member/committee_member.json
@@ -17,7 +17,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "User ID",
-   "options": "User",
+   "options": "User Signature",
    "reqd": 1,
    "search_index": 1
   },
@@ -30,6 +30,7 @@
    "label": "Full Name"
   },
   {
+   "fetch_from": "user_id.signature",
    "fieldname": "signature",
    "fieldtype": "Attach",
    "in_list_view": 1,
@@ -39,7 +40,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-09 10:49:22.892307",
+ "modified": "2025-08-09 12:12:38.312831",
  "modified_by": "Administrator",
  "module": "RFQ Opening Process",
  "name": "Committee Member",

--- a/rfq_opening_process/rfq_opening_process/doctype/committee_note/committee_note.js
+++ b/rfq_opening_process/rfq_opening_process/doctype/committee_note/committee_note.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on("Committee Note", {
   note_type(frm) {
+    frm.trigger("validateRFQ");
     frm.trigger("generateContent");
   },
   evaluation_committee(frm) {
@@ -29,6 +30,18 @@ frappe.ui.form.on("Committee Note", {
           }
         },
       });
+    }
+  },
+
+  validateRFQ(frm) {
+    if (!frm.doc.quotation) {
+      frappe.msgprint({
+        title: __("Error"),
+        indicator: "red",
+        message: __("Please select a Request for Quotation (RFQ)"),
+      });
+
+      return;
     }
   },
 });

--- a/rfq_opening_process/rfq_opening_process/doctype/committee_note/committee_note.json
+++ b/rfq_opening_process/rfq_opening_process/doctype/committee_note/committee_note.json
@@ -28,6 +28,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Request for Quotation",
+   "link_filters": "[[\"Request for Quotation\",\"committee\",\"is\",\"set\"]]",
    "options": "Request for Quotation",
    "reqd": 1
   },
@@ -101,7 +102,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-27 17:35:01.347590",
+ "modified": "2025-08-11 13:14:42.537414",
  "modified_by": "Administrator",
  "module": "RFQ Opening Process",
  "name": "Committee Note",
@@ -121,6 +122,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/rfq_opening_process/rfq_opening_process/doctype/rfq_opening_settings/rfq_opening_settings.json
+++ b/rfq_opening_process/rfq_opening_process/doctype/rfq_opening_settings/rfq_opening_settings.json
@@ -8,7 +8,8 @@
  "field_order": [
   "allow_multiple_supplier_quotations_from_portal",
   "skip_supplier_quotation_opening_by_committee",
-  "ignore_default_buying_price_list_validation"
+  "ignore_default_buying_price_list_validation",
+  "require_mandatory_on_rfq"
  ],
  "fields": [
   {
@@ -34,12 +35,20 @@
    "in_list_view": 1,
    "label": "Ignore Default Buying Price List Validation",
    "reqd": 1
+  },
+  {
+   "default": "1",
+   "description": "Sets the Committe, Minimum Expected Quotes, Closing Date and Closing Time as Mandatory fields on the RFQ",
+   "fieldname": "require_mandatory_on_rfq",
+   "fieldtype": "Check",
+   "label": "Require Mandatory On RFQ"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-11-03 13:49:25.716624",
+ "modified": "2025-08-09 13:17:24.566305",
  "modified_by": "Administrator",
  "module": "RFQ Opening Process",
  "name": "RFQ Opening Settings",
@@ -56,6 +65,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/rfq_opening_process/rfq_opening_process/doctype/user_signature/test_user_signature.py
+++ b/rfq_opening_process/rfq_opening_process/doctype/user_signature/test_user_signature.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Navari Limited and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestUserSignature(FrappeTestCase):
+	pass

--- a/rfq_opening_process/rfq_opening_process/doctype/user_signature/user_signature.js
+++ b/rfq_opening_process/rfq_opening_process/doctype/user_signature/user_signature.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Navari Limited and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("User Signature", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/rfq_opening_process/rfq_opening_process/doctype/user_signature/user_signature.json
+++ b/rfq_opening_process/rfq_opening_process/doctype/user_signature/user_signature.json
@@ -1,0 +1,92 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:user",
+ "creation": "2025-07-17 08:37:03.706772",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "user",
+  "full_name",
+  "column_break_qthd",
+  "signature"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fetch_from": "user.full_name",
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Full Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_qthd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "signature",
+   "fieldtype": "Attach",
+   "label": "Signature"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-08-09 12:15:56.107091",
+ "modified_by": "Administrator",
+ "module": "RFQ Opening Process",
+ "name": "User Signature",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "report": 1,
+   "role": "Desk User",
+   "select": 1,
+   "share": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1,
+ "track_views": 1
+}

--- a/rfq_opening_process/rfq_opening_process/doctype/user_signature/user_signature.py
+++ b/rfq_opening_process/rfq_opening_process/doctype/user_signature/user_signature.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Navari Limited and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class UserSignature(Document):
+	pass

--- a/rfq_opening_process/rfq_opening_process/patches/user_signature_migration.py
+++ b/rfq_opening_process/rfq_opening_process/patches/user_signature_migration.py
@@ -1,0 +1,25 @@
+import frappe 
+
+def execute():
+    # Check if the old custom field still exists
+    if not frappe.db.has_column("User", "signature"):
+        frappe.log_error("Column 'signature' not found in User table", "User Signature Migration")
+        return
+
+    users = frappe.get_all(
+        "User",
+        filters={"signature": ["is", "set"]},
+        fields=["name", "full_name", "signature"],
+    )
+
+    for user in users:
+        if not frappe.db.exists("User Signature", {"user": user.name}):
+            doc = frappe.get_doc({
+                "doctype": "User Signature",
+                "user": user.name,
+                "full_name": user.full_name,
+                "signature": user.signature
+            })
+            doc.insert(ignore_permissions=True)
+
+    frappe.db.commit()

--- a/rfq_opening_process/templates/includes/rfq_committee_register.html
+++ b/rfq_opening_process/templates/includes/rfq_committee_register.html
@@ -15,7 +15,7 @@
     </thead>
     <tbody>
       {% for idx, member in enumerate(committee_members) %}
-      {% set user_signature = frappe.db.get_value("User", {"name": member.user_id }, ["signature"]) %}
+      {% set user_signature = frappe.db.get_value("User Signature", {"name": member.user_id }, ["signature"]) %}
       <tr>
         <td>{{ idx + 1 }}</td>
         <td style="width: 30%">{{ member.get("full_name") }}</td>

--- a/rfq_opening_process/templates/includes/rfq_evaluation_minutes.html
+++ b/rfq_opening_process/templates/includes/rfq_evaluation_minutes.html
@@ -79,7 +79,7 @@
     </thead>
     <tbody>
       {% for idx, member in enumerate(evaluation_committee) %}
-      {% set user_signature = frappe.db.get_value("User", {"name": member.user_id }, ["signature"]) %}
+      {% set user_signature = frappe.db.get_value("User Signature", {"name": member.user_id }, ["signature"]) %}
       <tr>
         <td>{{ idx + 1 }}</td>
         <td style="width: 30%">{{ member.get("full_name") }}</td>

--- a/rfq_opening_process/templates/includes/rfq_opening_minutes.html
+++ b/rfq_opening_process/templates/includes/rfq_opening_minutes.html
@@ -84,9 +84,9 @@
     </thead>
     <tbody>
       {% for idx, member in enumerate(committee_members) %}
-      {% set user_signature = frappe.db.get_value("User", {"name": member.user_id }, ["signature"]) %}
+      {% set user_signature = frappe.db.get_value("User Signature", {"name": member.user_id }, ["signature"]) %}
       <tr>
-        <td>{{ idx + 1 }}</td>
+        <td>{{ loop.index }}</td>
         <td style="width: 30%">{{ member.get("full_name") }}</td>
         {% if user_signature%}
           <td style="width: 30%"><img width="100" height="25" src="{{ user_signature }}" /></td>


### PR DESCRIPTION
- remove fetch from in the signature field
- New doctype **User Signature** stores users and there signatures
- Migration script (patch) to create new records for users with already registered/uploaded signatures
- Updated .html templates to fetch the records from the User Signature doctype
- make custom fields on RFQ mandatory depending on RFQ Mandatory Settings option
- validate RFQ selection, filter RFQs, and improve date formatting